### PR TITLE
Fix dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
     "babel-eslint": "^7.2.3",
     "babel-jest": "^21.2.0",
     "babel-plugin-dev-expression": "^0.2.1",


### PR DESCRIPTION
This fixes a peer dep warning from `babel-jest`.