### PR TITLE
fix: don't change AST for other rules

### DIFF
--- a/src/ComplexityVisitor.js
+++ b/src/ComplexityVisitor.js
@@ -90,7 +90,6 @@ export default class ComplexityVisitor {
       enter: this.enterField,
       leave: this.leaveField,
     };
-
     this.FragmentDefinition = () => {
       // don't visit any further we will include these at the spread location
       return false;

--- a/test/fixtures/schema.js
+++ b/test/fixtures/schema.js
@@ -1,14 +1,53 @@
+/* eslint-disable no-use-before-define */
 import {
   GraphQLInt,
+  GraphQLInterfaceType,
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLSchema,
   GraphQLString,
+  GraphQLUnionType,
 } from 'graphql';
+
+const NamedItem = new GraphQLInterfaceType({
+  name: 'NamedItem',
+  fields: {
+    name: {
+      type: GraphQLString,
+      args: {
+        arg: { type: GraphQLInt },
+      },
+    },
+  },
+});
+
+const PolyItem = new GraphQLUnionType({
+  name: 'ItemUnion',
+  types: () => [Item, Item2],
+  resolveType: () => Item,
+});
+
+const Item2 = new GraphQLObjectType({
+  name: 'Item2',
+  interfaces: [NamedItem],
+  fields: () => ({
+    name: {
+      type: GraphQLString,
+      args: {
+        arg: { type: GraphQLInt },
+      },
+    },
+    number: { type: GraphQLInt },
+    extra: { type: GraphQLInt },
+    polyItem: { type: PolyItem },
+  }),
+});
 
 const Item = new GraphQLObjectType({
   name: 'Item',
+
+  interfaces: [NamedItem],
   fields: () => ({
     name: {
       type: GraphQLString,
@@ -18,6 +57,7 @@ const Item = new GraphQLObjectType({
     },
     number: { type: GraphQLInt },
     item: { type: Item },
+    polyItem: { type: PolyItem },
     expensiveItem: {
       type: Item,
       extensions: {


### PR DESCRIPTION
Ok this is annoying. I was hoping to avoid this sort of extra traversal. But I overlooked that _obvious_ changing the ast for one rule is going to affect what other rules see, even if the final AST isn't used for anything. So this was creating invalid tree's that were failing the built in rules. Now this does a full traversal isolated. This was easier than trying to do it the main visit loop and probably not much more inefficient 