### PR TITLE
publish typescript declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Query complexity validation for GraphQL.js",
   "typings": "index.d.ts",
   "files": [
-    "lib"
+    "lib",
+    "index.d.ts"
   ],
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Unfortunately #284 was lacking an important detail. The declaration file `index.d.ts` need to be explicitly stated in `package.json` in order to be included in the next published npm version. Sorry for that. Here a quick fix. Thanks.